### PR TITLE
Document QuickLook functionality

### DIFF
--- a/docs/Files and Folders.md
+++ b/docs/Files and Folders.md
@@ -56,6 +56,10 @@ There are many file and folder actions, but realize they work with Quicksilver�
 
 See the [Text Files](Text.md#text-files) section for actions that modify the contents of a text files.
 
+## Previewing A File With QuickLook
+
+To preview a file using QuickLook, type <kbd>⌘</kbd><kbd>Y</kbd>. To preview full-screen, use <kbd>⌥</kbd><kbd>⌘</kbd><kbd>Y</kbd> (these are the same shortcuts as in the Finder). QuickLook is also the default behavior of <kbd>Space</kbd> for some file types if "Spacebar behavior" is set to "Smart" or "QuickLook" in the Command section of the General preferences pane.
+
 ## File Tagging
 
 The File Attributes plugin allows Quicksilver to tag files and search for files based on one or more tags.


### PR DESCRIPTION
The only documentation I could find of how to trigger QuickLook was in the ß66 section of the [Changelog](https://qsapp.com/changelog.php). A web search mostly turns up references to scripts that predate built-in QuickLook functionality.