### PR TITLE
Add Homebrew to install and note on code signing

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -28,9 +28,21 @@ The latest version runs on macOS 10.10 or later. [Previous versions](https://qsa
 
 ## Installing Quicksilver
 
+From the Disc Image (.dmg) file:
+
   1. [Download Quicksilver](https://qsapp.com/download.php).
   2. Open the `.dmg` file and drag Quicksilver to your Applications folder.
   3. Unmount the Quicksilver volume and delete the `.dmg` file.
+
+Using Homebrew:
+
+[Homebrew is a package manager for OS X](https://brew.sh) for installs, updates and uninstalls of most OS X software:
+
+Open Terminal, type `brew install --cask quicksilver`. You can `uninstall` just as easily. 
+
+## First Launch
+
+Due to the way Quicksilver is built, OS X raises a [code signing warning (open issue)](https://github.com/quicksilver/Quicksilver/issues/2576))—the quickest way to get around this is to <kbd>ctrl-</kbd> or <kbd>right-click</kbd> the Quicksilver app in Applications, choose "open" from the contextual menu, *then* choose the *extra "open" button* that now appears in the warning dialog box. This only needs doing once, Quicksilver will then launch in future without further issue.
 
 On first launch, Quicksilver presents some setup options (it can be rerun later with the Run Setup button in the Application Preferences). Choose a shortcut that activates the Quicksilver command window, or just accept the default, <kbd>⌃</kbd><kbd>Space</kbd>. Quicksilver will recommend plugins based on applications you have installed and other criteria.
 

--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -42,7 +42,7 @@ Open Terminal, type `brew install --cask quicksilver`. You can `uninstall` just 
 
 ## First Launch
 
-Due to the way Quicksilver is built, OS X raises a [code signing warning (open issue)](https://github.com/quicksilver/Quicksilver/issues/2576))—the quickest way to get around this is to <kbd>ctrl-</kbd> or <kbd>right-click</kbd> the Quicksilver app in Applications, choose "open" from the contextual menu, *then* choose the *extra "open" button* that now appears in the warning dialog box. This only needs doing once, Quicksilver will then launch in future without further issue.
+Due to the way Quicksilver is built, macOS raises a [code signing warning (open issue)](https://github.com/quicksilver/Quicksilver/issues/2576))—the quickest way to get around this is to <kbd>ctrl-</kbd> or <kbd>right-click</kbd> the Quicksilver app in Applications, choose "open" from the contextual menu, *then* choose the *extra "open" button* that now appears in the warning dialog box. This only needs doing once, Quicksilver will then launch in future without further issue.
 
 On first launch, Quicksilver presents some setup options (it can be rerun later with the Run Setup button in the Application Preferences). Choose a shortcut that activates the Quicksilver command window, or just accept the default, <kbd>⌃</kbd><kbd>Space</kbd>. Quicksilver will recommend plugins based on applications you have installed and other criteria.
 


### PR DESCRIPTION
Many Mac users have the Homebrew package manager so added brew install to the guide, and a note on first launch about circumventing the code signing issue